### PR TITLE
Support of larger documents

### DIFF
--- a/Method_1_Script.js
+++ b/Method_1_Script.js
@@ -16,7 +16,6 @@
         for (i = imgCount; i < imgTags.length; i++) {
 
             if (imgTags[i].src.substring(0, checkURLString.length) === checkURLString){
-                imgCount = i;
                 validImgTagCounter = validImgTagCounter + 1;
                 //console.log(imgTags[i].src);
                 let img = imgTags[i];
@@ -40,6 +39,7 @@
                     console.log(imgCount, imgTags.length)
                     break;
                 }
+                imgCount = i;
             }
         }
 

--- a/Method_1_Script.js
+++ b/Method_1_Script.js
@@ -1,14 +1,22 @@
 
-    let pdfDocumentName = "Document";
-    let doc = "";
+    // Variables to be edited by user
+    let pdfDocumentName = "BytesBin_PDF";
+    let scrollSpeed = 300
+    let earlyStop = false
 
-    function generatePDF_DataFile (){
+    // Global variable
+    var imgCount = 0
+
+    function generatePDF_DataFile (){ 
+        let doc = "";
         let imgTags = document.getElementsByTagName("img");
         let checkURLString = "blob:https://drive.google.com/";
         let validImgTagCounter = 0;
-        for (i = 0; i < imgTags.length; i++) {
+        // console.log("image", imgCount)
+        for (i = imgCount; i < imgTags.length; i++) {
 
             if (imgTags[i].src.substring(0, checkURLString.length) === checkURLString){
+                imgCount = i;
                 validImgTagCounter = validImgTagCounter + 1;
                 //console.log(imgTags[i].src);
                 let img = imgTags[i];
@@ -20,14 +28,18 @@
                 //console.log("Width: " + img.naturalWidth + ", Height: " + img.naturalHeight);
                 context.drawImage(img, 0, 0, img.naturalWidth, img.naturalHeight);
                 let imgDataURL = canvas.toDataURL();
-               // console.log(imgDataURL);
-
-                if (doc === ""){
-                    doc = imgDataURL;
-                }else{
-                    doc = doc + "\n" + imgDataURL;
+                // console.log(imgDataURL);
+            
+                try{
+                    if (doc === ""){
+                        doc = imgDataURL;
+                    }else{
+                        doc = doc + "\n" + imgDataURL;
+                    }
+                } catch{
+                    console.log(imgCount, imgTags.length)
+                    break;
                 }
-
             }
         }
 
@@ -39,6 +51,12 @@
         anchorElement.download = pdfDocumentName + ".PDF_DataFile";
         document.body.appendChild(anchorElement);
         anchorElement.click();
+        
+        if(imgCount + 1 < imgTags.length){
+            console.log("Please keep the tab open. Still processing the document. Remaining images:", imgTags.length - imgCount - 1)
+            generatePDF_DataFile(); 
+        } 
+        else console.log("Script done. You can now safely close the document.");
     }
 
     let allElements = document.querySelectorAll("*");
@@ -59,9 +77,9 @@
     if (chosenElement.scrollHeight > chosenElement.clientHeight){
         console.log("Auto Scroll");
 
-        let scrollDistance = Math.round(chosenElement.clientHeight/2);
-        //console.log("scrollHeight: " + chosenElement.scrollHeight);
-        //console.log("scrollDistance: " + scrollDistance);
+        let scrollDistance = Math.round(chosenElement.clientHeight);
+        console.log("scrollHeight: " + chosenElement.scrollHeight);
+        console.log("scrollDistance: " + scrollDistance);
 
         let loopCounter = 0;
         function myLoop(remainingHeightToScroll, scrollToLocation) {
@@ -79,7 +97,8 @@
                     remainingHeightToScroll = remainingHeightToScroll - scrollDistance;
                 }
 
-                if (remainingHeightToScroll >= chosenElement.clientHeight){
+                // console.log("remainingHeightToScroll", remainingHeightToScroll)
+                if (remainingHeightToScroll>= chosenElement.clientHeight && !earlyStop){
                     myLoop(remainingHeightToScroll, scrollToLocation)
                 }else{
                     setTimeout(function() {
@@ -87,7 +106,7 @@
                     }, 1500)
                 }
 
-            }, 400)
+            }, scrollSpeed)
         }
         myLoop(0, 0);
 


### PR DESCRIPTION
The doc variable has a limited length. The script crashes when the document becomes too large.
my work around: I surround the append code section of the existing function with a try block and store the last successful imgTag in the variable 'imgCount'. If 'imgCount' is less than the number of 'imgTags' then we know that we have to start over but at the first tag where it went wrong before aka the 'imgCount'. With this method, the user has multiple '.PDF_DataFile' files after execution of the script which can be easily converted to PDF by the existing scripts. All that needs to be done at the end is a merge of all PDF files, which can be done very easily online.

I've also implemented a variable 'earlyStop'. If the user wants to stop the scan early, all they need to do is set this boolean to true in the console of the browser. The scanning process will stop and the conversion will begin.

This code worked in my case (google doc with 900+ pages). Test my addition to make sure it performs to your liking.